### PR TITLE
Implemented "interval" property to optionally poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 pimatic sispmctl plugin
 =======================
 Backend for the [SIS-PM Control for Linux aka sispmct](http://sispmctl.sourceforge.net/) 
-application that can control GEMBIRD (m)SiS-PM device, witch are USB controled multiple socket.
+application that can control GEMBIRD (m)SiS-PM device, witch are USB controlled multiple socket.
 
 Configuration
 -------------
@@ -24,4 +24,4 @@ Set the `class` attribute to `SispmctlSwitch`. For example:
       "outletUnit": 1 
     }
 
-For actuator configuration options see the [actuator-config-schema](actuator-config-schema.html) file.
+For device configuration options see the [device-config-schema](device-config-schema.html) file.

--- a/device-config-schema.coffee
+++ b/device-config-schema.coffee
@@ -1,5 +1,5 @@
 module.exports = {
-  title: "pimatic-sispmctrl device config schemas"
+  title: "pimatic-sispmctl device config schemas"
   SispmctlSwitch: {
     title: "SispmctlSwitch config options"
     type: "object"
@@ -9,17 +9,20 @@ module.exports = {
         description: "The outlet unit number"
         type: "number"
       device: 
-        # If you have more than on device then you can select the device the outlet belons to.
+        # If you have more than on device then you can select the device the outlet belongs to.
         description: "The device to use. Devices can be listed by \"sudo sispmctl -s\""
         type: "number"
         default: 0
       deviceSerial:
-        # If you have more than on device then you gcan select the device by serial the outlet 
-        # belons to.
+        # If you have more than on device then you can select the device by serial the outlet
+        # belongs to.
         description: "Can be used instead of device to identify the device by serial number. 
           Devices can be listed by \"sudo sispmctl -s\""
         type: "string"
         required: false
+      interval:
+        description: "Polling interval in ms for reading the switch state. If 0, no polling is performed"
+        type: "number"
+        default: 0
   }
-
 }

--- a/sispmctl.coffee
+++ b/sispmctl.coffee
@@ -43,6 +43,8 @@ module.exports = (env) ->
     _updateStatus: () ->
       setTimeout () =>
         @_getState()
+        .catch (error) =>
+          env.logger.error error.message ? error
         .finally () =>
           @_updateStatus()
       , @config.interval

--- a/sispmctl.coffee
+++ b/sispmctl.coffee
@@ -9,7 +9,7 @@ module.exports = (env) ->
   class Sispmctl extends env.plugins.Plugin
 
     init: (app, @framework, @config) =>
-      # lastAction is a promise for the last/current sispmctrl call, wel always chain on
+      # lastAction is a promise for the last/current sispmctl call, wel always chain on
       # this so that sispmctl gets never called while its already running.
       @_lastAction = @checkBinary()
       @_lastAction.done()
@@ -38,37 +38,49 @@ module.exports = (env) ->
       @name = config.name
       @id = config.id
       super()
+      @_updateStatus() if @config.interval > 0
 
-    getState: () ->
-      if @_state? then return Promise.resolve @_state
-      # Built the sispmctrl command to get the outlet status
+    _updateStatus: () ->
+      setTimeout () =>
+        @_getState()
+        .finally () =>
+          @_updateStatus()
+      , @config.interval
+
+    _getState: () ->
+      # Build the sispmctl command to get the outlet status
       command = "#{plugin.config.binary} -q -n" # quiet and numerical
       if @config.deviceSerial?
         command += " -D #{@config.deviceSerial}" # select the device
       else
         command += " -d #{@config.device}" # select the device
       command += " -g #{@config.outletUnit}" # get status of the outlet
-      # and execue it.
+      # and execute it.
       return plugin.exec(command).then( (streams) =>
         stdout = streams[0]
         stderr = streams[1]
         stdout = stdout.trim()
         switch stdout
           when "1"
-            @_state = on
+            @_setState(on)
             return Promise.resolve @_state
           when "0"
-            @_state = off
+            @_setState(off)
             return Promise.resolve @_state
           else 
             env.logger.debug stderr
             throw new Error "SispmctlSwitch: unknown state=\"#{stdout}\"!"
       )
-        
+
+    getState: () ->
+      if @_state?
+        return Promise.resolve @_state
+      else
+        return @_getState()
 
     changeStateTo: (state) ->
       if @state is state then return
-      # Built the sispmctrl command
+      # Build the sispmctl command
       command = "#{plugin.config.binary}"
       if @config.deviceSerial?
         command += " -D #{@config.deviceSerial}" # select the device
@@ -76,7 +88,7 @@ module.exports = (env) ->
         command += " -d #{@config.device}" # select the device
       command += " " + (if state then "-o" else "-f") # do on or off
       command += " " + @config.outletUnit # select the outlet
-      # and execue it.
+      # and execute it.
       return plugin.exec(command).then( (streams) =>
         stdout = streams[0]
         stderr = streams[1]


### PR DESCRIPTION
Implemented "interval" property to optionally poll  (if interval > 0) the USB switch for its state. This is useful if the switch is also controlled by other applications.  See http://forum.pimatic.org/topic/1334/plugin-sispmctl-update-interval

Fixed several typos.
